### PR TITLE
Add vault_to_vault transfers.

### DIFF
--- a/lib/fireblocks/api/transactions.rb
+++ b/lib/fireblocks/api/transactions.rb
@@ -50,6 +50,27 @@ module Fireblocks
           }
           create(body)
         end
+
+        def from_vault_to_vault(
+          amount:,
+          asset_id:,
+          source_id:,
+          destination_id:
+        )
+          body = {
+            amount: amount,
+            assetId: asset_id,
+            source: {
+              type: 'VAULT_ACCOUNT',
+              id: source_id
+            },
+            destination: {
+              type: 'VAULT_ACCOUNT',
+              id: destination_id
+            }
+          }
+          create(body)
+        end
       end
     end
   end

--- a/lib/fireblocks/version.rb
+++ b/lib/fireblocks/version.rb
@@ -3,6 +3,6 @@
 module Fireblocks
   MAJOR = 0
   MINOR = 2
-  TINY = 7
+  TINY = 8
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze
 end


### PR DESCRIPTION
### Description

For trade desk rebalancing, we want to send vault to vault transfers rather than vault to external transfers. This PR adds a `from_vault_to_vault` method to `Fireblocks::API::Transactions`.