### PR TITLE
Add ability to pass options to fb

### DIFF
--- a/lib/fireblocks/api/transactions.rb
+++ b/lib/fireblocks/api/transactions.rb
@@ -10,6 +10,7 @@ module Fireblocks
           source
           destination
           fee
+          feeLevel
           gasPrice
           note
           autoStaking
@@ -28,7 +29,8 @@ module Fireblocks
           source_id:,
           destination_id:,
           one_time_address:,
-          tag: nil
+          tag: nil,
+          options: {}
         )
           one_time_address_hash = {
             address: one_time_address
@@ -47,7 +49,8 @@ module Fireblocks
               id: destination_id,
               oneTimeAddress: one_time_address_hash
             }
-          }
+          }.merge(options)
+
           create(body)
         end
 
@@ -55,7 +58,8 @@ module Fireblocks
           amount:,
           asset_id:,
           source_id:,
-          destination_id:
+          destination_id:,
+          options: {}
         )
           body = {
             amount: amount,
@@ -68,7 +72,8 @@ module Fireblocks
               type: 'VAULT_ACCOUNT',
               id: destination_id
             }
-          }
+          }.merge(options)
+
           create(body)
         end
       end

--- a/lib/fireblocks/version.rb
+++ b/lib/fireblocks/version.rb
@@ -3,6 +3,6 @@
 module Fireblocks
   MAJOR = 0
   MINOR = 2
-  TINY = 9
+  TINY = 10
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze
 end


### PR DESCRIPTION
We need a way to set `feeLevel` and we currently do not have a way to pass that in from the API.
This PR accepts a hash of options that will get merged into the request body.
