### PR TITLE
[CRYPTO-141] use old workspace credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ gem install fireblocks
 Add to your `Gemfile`:
 
 ```ruby
-gem "fireblocks", "~> 0.2.3"
+gem "fireblocks", "~> 0.3.0"
 ```
+
+Check [version file](https://github.com/fundamerica/fireblocks/blob/86cf22bdda88450892d151b13e10c7d397b1e034/lib/fireblocks/version.rb) for most current.
 
 Run `bundle install`
 

--- a/lib/fireblocks/api/transactions.rb
+++ b/lib/fireblocks/api/transactions.rb
@@ -84,7 +84,7 @@ module Fireblocks
             }
           }.merge(options).compact
 
-          create(body, headers: {})
+          create(body, headers: headers)
         end
 
         def destination_payload(**kwargs)

--- a/lib/fireblocks/configuration.rb
+++ b/lib/fireblocks/configuration.rb
@@ -7,7 +7,7 @@ module Fireblocks
   #
   class Configuration
     Error = Class.new(StandardError)
-    attr_writer :api_key, :private_key
+    attr_writer :api_key, :private_key, :api_key_old_primetrust, :private_key_old_primetrust
 
     attr_accessor :base_url, :tenant_id
 
@@ -15,6 +15,8 @@ module Fireblocks
       @api_key = nil
       @private_key = nil
       @tenant_id = nil
+      @api_key_old_primetrust = nil
+      @private_key_old_primetrust = nil
       @base_url = 'https://api.fireblocks.io'
     end
 
@@ -34,6 +36,24 @@ module Fireblocks
       raise Error, message unless @private_key
 
       @private_key
+    end
+
+    def api_key_old_primetrust
+      message =
+        'Fireblocks api key for old workspace not set. See Fireblocks documentation ' \
+        'to get a hold of your api key'
+      raise Error, message unless @api_key_old_primetrust
+
+      @api_key_old_primetrust
+    end
+
+    def private_key_old_primetrust
+      message =
+        'Fireblocks private key for old workspace not set. See Fireblocks documentation ' \
+        'to get a hold of your private key'
+      raise Error, message unless @private_key_old_primetrust
+
+      @private_key_old_primetrust
     end
   end
 end

--- a/lib/fireblocks/version.rb
+++ b/lib/fireblocks/version.rb
@@ -2,7 +2,7 @@
 
 module Fireblocks
   MAJOR = 0
-  MINOR = 2
-  TINY = 15
+  MINOR = 3
+  TINY = 0
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze
 end


### PR DESCRIPTION
This PR is part of Jira ticket [CRYPTO-141](https://primetrustspc.atlassian.net/browse/CRYPTO-141).
Related changes are in prime trust api [CRYPTO-141](https://github.com/fundamerica/prime_trust_api/pull/3185)

### What is changing and why.
For our Asset Sweep feature, we will be using some asset transfer methods that are connected to the old workspace. In order to request a fireblocks transaction to sweep asset from the old workspace (they will go to the new workspace) we have to use the credentials for the old workspace. 

Note: Only the production environment has the old workspace setup. It does not exist, not does its api or private keys in the other environments.

This PR adds a `workspace` param in the `Request` and `Token` classes that will be used to determine which api and private keys to use. If there is no workspace param, then the 'CURRENT` workspace will be used.