### PR TITLE
[Crypto-163] add forceSweep to fireblocks transactions

### DIFF
--- a/lib/fireblocks/api/transactions.rb
+++ b/lib/fireblocks/api/transactions.rb
@@ -21,6 +21,7 @@ module Fireblocks
           source
           treatAsGrossAmount
           headers
+          forceSweep
         ].freeze
 
         def create(options, headers = {})

--- a/lib/fireblocks/version.rb
+++ b/lib/fireblocks/version.rb
@@ -3,6 +3,6 @@
 module Fireblocks
   MAJOR = 0
   MINOR = 3
-  TINY = 0
+  TINY = 1
   VERSION = [MAJOR, MINOR, TINY].join('.').freeze
 end


### PR DESCRIPTION
Problem: need to pass forceSweep to fireblocks during sweeping
Solution: adding forceSweep as an available option.